### PR TITLE
Required changes for Ninja generator on Windows

### DIFF
--- a/LuaJIT.cmake
+++ b/LuaJIT.cmake
@@ -566,7 +566,8 @@ add_dependencies(libluajit
   lj_gen_folddef)
 target_include_directories(libluajit PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(libluajit PUBLIC
   ${LJ_DIR})
 if(BUILD_SHARED_LIBS)
   if(WIN32)

--- a/host/buildvm/CMakeLists.txt
+++ b/host/buildvm/CMakeLists.txt
@@ -50,5 +50,6 @@ target_include_directories(buildvm PRIVATE
   ${LUAJIT_DIR}/src/host
   ${CMAKE_BINARY_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/..
+  ${CMAKE_CURRENT_BINARY_DIR}/../..
   ${CMAKE_CURRENT_BINARY_DIR}/../../..
   ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
I needed to make these two small changes to use this wonderful library with Ninja on Windows. I needed to make the `${LJ_DIR}` include for `libluajit` public so my executable depending on `libluajit` could access the headers without modifying its own includes which would be messy. And I needed to add `${CMAKE_CURRENT_BINARY_DIR}/../..` to the includes for `buildvm` because `buildvm_arch.h` was ending up in a weird place under Ninja.