### PR TITLE
Add luajit::lua alias only if LUAJIT_BUILD_EXE is TRUE

### DIFF
--- a/LuaJIT.cmake
+++ b/LuaJIT.cmake
@@ -664,4 +664,6 @@ target_include_directories(luajit-header INTERFACE ${LJ_DIR})
 
 add_library(luajit::lib ALIAS libluajit)
 add_library(luajit::header ALIAS luajit-header)
-add_executable(luajit::lua ALIAS luajit)
+if (LUAJIT_BUILD_EXE)
+  add_executable(luajit::lua ALIAS luajit)
+endif()


### PR DESCRIPTION
Fix for https://github.com/zhaozg/luajit-cmake/issues/11 CMake generation fails if LUAJIT_BUILD_EXE is set to false