### PR TITLE
Have the creation of luajit::lua ALIAS depend on LUAJIT_BUILD_EXE

### DIFF
--- a/LuaJIT.cmake
+++ b/LuaJIT.cmake
@@ -686,4 +686,6 @@ target_include_directories(luajit-header INTERFACE ${LJ_DIR})
 
 add_library(luajit::lib ALIAS libluajit)
 add_library(luajit::header ALIAS luajit-header)
-add_executable(luajit::lua ALIAS luajit)
+if (LUAJIT_BUILD_EXE)
+  add_executable(luajit::lua ALIAS luajit)
+endif()


### PR DESCRIPTION
currently it does not, and an error is thrown when LUAJIT_BUILD_EXE is OFF, as the executable being aliased does not exist.